### PR TITLE
Add `enable_current_user_cluster_admin` variable

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.75.1"
-  constraints = ">= 4.0.0, >= 4.33.0, ~> 5.0, >= 5.46.0, >= 5.59.0, >= 5.62.0, >= 5.75.0"
+  version     = "5.76.0"
+  constraints = ">= 4.33.0, ~> 5.0, >= 5.46.0, >= 5.59.0, >= 5.62.0, >= 5.75.0"
   hashes = [
-    "h1:uz55I4t3Pqy3p+82NZ35mkUA9mZ5yu4pS6beZMI8wpA=",
-    "zh:1075825e7311a8d2d233fd453a173910e891b0320e8a7698af44d1f90b02621d",
-    "zh:203c5d09a03fcaa946defb8459f01227f2fcda07df768f74777beb328d6751ae",
-    "zh:21bc79ccb09bfdeb711a3a5226c6c4a457ac7c4bb781dbda6ade7be38461739f",
-    "zh:2bac969855b62a0ff6716954be29387a1f9793626059122cda4681206396e309",
-    "zh:4b65ea5b51058f05b9ec8797f76184e19e5b38a609029fe2226af3fa4ad289b3",
-    "zh:5065d7df357fb3ee2b0a2520bbcff6335c0c47bfb9e8e9932bad088c3ab7efd3",
-    "zh:678a4015a4cd26af5c2b30dfd9290b8a01e900668fa0fec6585dfd1838f1cebd",
-    "zh:6ddc5dfdd4a0dddca027db99a7bfa9a0978933119d63af81acb6020728405119",
-    "zh:98c0d48b09842c444dbcbddd279e5b5b1e44113951817a8ecc28896bb4ad1dd7",
+    "h1:bYc0hbgVRXYCiapr/EgjdP8ohcwFjninfknZvqHQZPQ=",
+    "zh:05b2a0d25fc07576f6698d4840d0d2ae2599484c49f1b911ea1154584557bc13",
+    "zh:1b22dd1d9c482739e133adb996a9c8b285ca7d978d0fe04deaa5588eba5d254c",
+    "zh:216088c8800e7b8d7eff7b1a822317bc6faec64f27946ffd22bb3494ac4175cb",
+    "zh:43e994112b1484bf49945c4885aa2fee32486c9a5d64b9146bbd6f309f24e332",
+    "zh:46a28ba800f176eef500f998217bccc331605ef05f11abb1728f727a81f3a8b0",
+    "zh:4fad2743174a600da76a0cceeec2fef8399a18d880ba8929d811cd5cea1b5dee",
+    "zh:5c42a2c1438cd7533456026f52b562715664490711fdea809f44610a7565c145",
+    "zh:792d4fd4be434682e4540d2579505c7f11f39d0efe1d12ee2761ed0d46c8cd51",
+    "zh:7bb5f9f87c9da6d62d6f89504f01a9d6d2f19dcaa0efc46ea51ebdc4bb6fd536",
+    "zh:81cdbd97f81b1110fce793944d5668a4389904979eb7d178d3142a6b0e175e5e",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:aad169fea072842c0b54f1ff95f1ec6558d6c5af3ea4c159308583db59003b09",
-    "zh:bd2625ed8e1ff29ac6ed3a810d7b68a090add5fcb2fce4122669bd37e1eb9f1d",
-    "zh:c6f57625e26a6ef1ffb49bfa0e6148496ad12d80c857f6bb222e21f293a2a78a",
-    "zh:c7cd085326c5eb88804b11a4bc0fbc8376f06138f4b9624fb25cd06ea8687cdd",
-    "zh:f60c98139f983817d4d08f4138b1e53f31f91176ff638631e8dd38b6de36fce0",
+    "zh:ab4b881eb0f3812b702aaecf921c5c16bbcc33d61d668be4d72d6da9c57ded85",
+    "zh:c1d9d1166fd948845614deef81f3197568d0d3c2a03b8b97fff308ebc59043f9",
+    "zh:cda7530f2c01434e483d3faf62fc0685295e7f844176aa38df1ba65fa6a4407a",
+    "zh:fdad558b1c41aa68123d0da82cc0d65bc86d09eaa1ab1d3a167ec3bce0fc0c66",
   ]
 }
 
@@ -66,7 +66,7 @@ provider "registry.terraform.io/hashicorp/helm" {
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.33.0"
-  constraints = "~> 2.0, >= 2.10.0"
+  constraints = "~> 2.0"
   hashes = [
     "h1:HDyytvOlqNw5fJ0SB/nzgqCWniK4LAZNx23LaPavQq8=",
     "zh:255b35790b706d405e987750190658dcaefb663741b96803a9529ba5d7435329",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The module has been tested with:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.76.0 |
 
 ## Modules
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -19,7 +19,7 @@ module "materialize_infrastructure" {
 
   # EKS Configuration
   cluster_version           = "1.31"
-  node_group_instance_types = ["t3.medium"]
+  node_group_instance_types = ["m6g.medium"]
   node_group_desired_size   = 2
   node_group_min_size       = 1
   node_group_max_size       = 3
@@ -43,7 +43,7 @@ module "materialize_infrastructure" {
 
   # Basic monitoring
   enable_monitoring      = true
-  metrics_retention_days = 7
+  metrics_retention_days = 3
 
   # Tags
   tags = {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -18,12 +18,13 @@ module "materialize_infrastructure" {
   single_nat_gateway   = true
 
   # EKS Configuration
-  cluster_version           = "1.31"
-  node_group_instance_types = ["m6g.medium"]
-  node_group_desired_size   = 2
-  node_group_min_size       = 1
-  node_group_max_size       = 3
-  node_group_capacity_type  = "ON_DEMAND"
+  cluster_version                   = "1.31"
+  node_group_instance_types         = ["m6g.medium"]
+  node_group_desired_size           = 2
+  node_group_min_size               = 1
+  node_group_max_size               = 3
+  node_group_capacity_type          = "ON_DEMAND"
+  enable_current_user_cluster_admin = true
 
   # Storage Configuration
   bucket_name              = "materialize-simple-storage-${random_id.suffix.hex}"
@@ -58,7 +59,12 @@ resource "random_id" "suffix" {
   byte_length = 4
 }
 
-# outputs.tf
+# Outputs
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.materialize_infrastructure.vpc_id
+}
+
 output "eks_cluster_endpoint" {
   description = "EKS cluster endpoint"
   value       = module.materialize_infrastructure.eks_cluster_endpoint
@@ -72,4 +78,25 @@ output "database_endpoint" {
 output "s3_bucket_name" {
   description = "Name of the S3 bucket"
   value       = module.materialize_infrastructure.s3_bucket_name
+}
+
+output "metadata_backend_url" {
+  description = "PostgreSQL connection URL in the format required by Materialize"
+  value       = module.materialize_infrastructure.metadata_backend_url
+  sensitive   = true
+}
+
+output "persist_backend_url" {
+  description = "S3 connection URL in the format required by Materialize using IRSA"
+  value       = module.materialize_infrastructure.persist_backend_url
+}
+
+output "oidc_provider_arn" {
+  description = "The ARN of the OIDC Provider"
+  value       = module.materialize_infrastructure.oidc_provider_arn
+}
+
+output "materialize_s3_role_arn" {
+  description = "The ARN of the IAM role for Materialize"
+  value       = module.materialize_infrastructure.materialize_s3_role_arn
 }

--- a/main.tf
+++ b/main.tf
@@ -14,18 +14,19 @@ module "networking" {
 module "eks" {
   source = "./modules/eks"
 
-  cluster_name              = var.cluster_name
-  cluster_version           = var.cluster_version
-  vpc_id                    = module.networking.vpc_id
-  private_subnet_ids        = module.networking.private_subnet_ids
-  environment               = var.environment
-  node_group_desired_size   = var.node_group_desired_size
-  node_group_min_size       = var.node_group_min_size
-  node_group_max_size       = var.node_group_max_size
-  node_group_instance_types = var.node_group_instance_types
-  tags                      = var.tags
-  cluster_enabled_log_types = var.cluster_enabled_log_types
-  node_group_capacity_type  = var.node_group_capacity_type
+  cluster_name                      = var.cluster_name
+  cluster_version                   = var.cluster_version
+  vpc_id                            = module.networking.vpc_id
+  private_subnet_ids                = module.networking.private_subnet_ids
+  environment                       = var.environment
+  node_group_desired_size           = var.node_group_desired_size
+  node_group_min_size               = var.node_group_min_size
+  node_group_max_size               = var.node_group_max_size
+  node_group_instance_types         = var.node_group_instance_types
+  tags                              = var.tags
+  cluster_enabled_log_types         = var.cluster_enabled_log_types
+  node_group_capacity_type          = var.node_group_capacity_type
+  enable_current_user_cluster_admin = var.enable_current_user_cluster_admin
 }
 
 module "storage" {

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -33,5 +33,30 @@ module "eks" {
     }
   }
 
+  access_entries = {
+    current_user = {
+      kubernetes_groups = ["administrators"]
+      principal_arn     = local.sso_role_arn
+
+      policy_associations = {
+        eks_admin_access = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+
   tags = var.tags
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Extract the role name from the assumed role ARN
+  assumed_role_name = split("/", data.aws_caller_identity.current.arn)[1]
+  # Construct the IAM role ARN for SSO
+  sso_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${local.assumed_role_name}"
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -60,3 +60,9 @@ variable "node_group_capacity_type" {
   type        = string
   default     = "ON_DEMAND"
 }
+
+variable "enable_current_user_cluster_admin" {
+  description = "Enable cluster admin access for the current AWS SSO user"
+  type        = bool
+  default     = true
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -18,3 +18,5 @@ node_group_max_size       = 5
 db_instance_class    = "db.t3.micro"
 db_allocated_storage = 20
 db_multi_az          = false
+
+enable_current_user_cluster_admin = true

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,12 @@ variable "cluster_enabled_log_types" {
   default     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 }
 
+variable "enable_current_user_cluster_admin" {
+  description = "Enable cluster admin access for the current AWS SSO user"
+  type        = bool
+  default     = true
+}
+
 # RDS Variables
 variable "db_identifier" {
   description = "Identifier for the RDS instance"


### PR DESCRIPTION
Adding a `enable_current_user_cluster_admin` variable, to allow users to have their current SSO role to be added as a cluster admin if needed.