### PR TITLE
Switch defaults to r8g node types

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The module has been tested with:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.84.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.87.0 |
 
 ## Modules
 
@@ -85,7 +85,7 @@ The module has been tested with:
 | <a name="input_node_group_ami_type"></a> [node\_group\_ami\_type](#input\_node\_group\_ami\_type) | AMI type for the node group | `string` | `"AL2023_ARM_64_STANDARD"` | no |
 | <a name="input_node_group_capacity_type"></a> [node\_group\_capacity\_type](#input\_node\_group\_capacity\_type) | Capacity type for worker nodes (ON\_DEMAND or SPOT) | `string` | `"ON_DEMAND"` | no |
 | <a name="input_node_group_desired_size"></a> [node\_group\_desired\_size](#input\_node\_group\_desired\_size) | Desired number of worker nodes | `number` | `2` | no |
-| <a name="input_node_group_instance_types"></a> [node\_group\_instance\_types](#input\_node\_group\_instance\_types) | Instance types for worker nodes.<br/><br/>Recommended Configuration for Running Materialize with disk:<br/>- Tested instance types: `m6g`, `m7g` families (ARM-based Graviton instances)<br/>- AMI: AWS Bottlerocket (optimized for container workloads)<br/>- Note: Ensure instance store volumes are available and attached to the nodes for optimal performance with disk-based workloads. | `list(string)` | <pre>[<br/>  "r7g.2xlarge"<br/>]</pre> | no |
+| <a name="input_node_group_instance_types"></a> [node\_group\_instance\_types](#input\_node\_group\_instance\_types) | Instance types for worker nodes.<br/><br/>Recommended Configuration for Running Materialize with disk:<br/>- Tested instance types: `m6g`, `m7g` families (ARM-based Graviton instances)<br/>- AMI: AWS Bottlerocket (optimized for container workloads)<br/>- Note: Ensure instance store volumes are available and attached to the nodes for optimal performance with disk-based workloads. | `list(string)` | <pre>[<br/>  "r8g.2xlarge"<br/>]</pre> | no |
 | <a name="input_node_group_max_size"></a> [node\_group\_max\_size](#input\_node\_group\_max\_size) | Maximum number of worker nodes | `number` | `4` | no |
 | <a name="input_node_group_min_size"></a> [node\_group\_min\_size](#input\_node\_group\_min\_size) | Minimum number of worker nodes | `number` | `1` | no |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | Namespace for the Materialize operator | `string` | `"materialize"` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -21,7 +21,7 @@ module "materialize_infrastructure" {
 
   # EKS Configuration
   cluster_version                          = "1.32"
-  node_group_instance_types                = ["r7g.2xlarge"]
+  node_group_instance_types                = ["r8g.2xlarge"]
   node_group_desired_size                  = 1
   node_group_min_size                      = 1
   node_group_max_size                      = 2

--- a/variables.tf
+++ b/variables.tf
@@ -111,7 +111,7 @@ Recommended Configuration for Running Materialize with disk:
 - Note: Ensure instance store volumes are available and attached to the nodes for optimal performance with disk-based workloads.
 EOF
   type        = list(string)
-  default     = ["r7g.2xlarge"]
+  default     = ["r8g.2xlarge"]
 }
 
 variable "node_group_capacity_type" {


### PR DESCRIPTION
As suggested by @def-, switching to r8g nodes.

The r8g.2xlarge runs on Graviton4, while the r7g.2xlarge uses Graviton3. The main difference is that r8g is faster and has better memory. Everything else—vCPUs, RAM, network, and price stays the same I believe:

1. https://aws.amazon.com/ec2/instance-types/r8g/
3. https://aws.amazon.com/ec2/instance-types/r7g/
