### PR TITLE
Switch Kubernetes provider to use exec auth for fresh EKS tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The module has been tested with:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.84.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.87.0 |
 
 ## Modules
 
@@ -46,7 +46,6 @@ The module has been tested with:
 | [aws_iam_user.materialize](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy.materialize_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/datasources.tf
+++ b/datasources.tf
@@ -1,6 +1,2 @@
-data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_name
-}
-
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,12 @@
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+  }
 }
 
 provider "helm" {


### PR DESCRIPTION
This PR updates the Kubernetes provider to use the `exec` authentication method with `aws eks get-token`, instead of relying on `data.aws_eks_cluster_auth`. We already use the `exec` auth method for the Helm TF provider so that way we will be consistent.

The previous approach used a short-lived token (15-minute TTL), which @def- noticed expired during Terraform applies in our CI.

More details on token expiration issues:  
[HashiCorp Troubleshooting Guide](https://support.hashicorp.com/hc/en-us/articles/33726394346259-Troubleshoot-Frequent-Timeout-to-Kubernetes-Control-Plane-API-or-Cluster-Unreachable-Issues#:~:text=Since%20the%20token%20generated%20using,the%20client%20to%20provide%20credentials)
