### PR TITLE
Trivial update namespace variable max length

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@ variable "namespace" {
   description = "Namespace for all resources, usually the organization or project name"
   type        = string
   validation {
-    condition     = length(var.namespace) <= 12 && can(regex("^[a-z0-9-]+$", var.namespace))
-    error_message = "Namespace must be lowercase alphanumeric and hyphens only, max 12 characters"
+    condition     = length(var.namespace) <= 12 && can(regex("^[a-z][a-z0-9-]+$", var.namespace))
+    error_message = "Namespace must be lowercase alphanumeric and hyphens only, start with a letter, max 12 characters"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@ variable "namespace" {
   description = "Namespace for all resources, usually the organization or project name"
   type        = string
   validation {
-    condition     = length(var.namespace) <= 18 && can(regex("^[a-z0-9-]+$", var.namespace))
-    error_message = "Namespace must be lowercase alphanumeric and hyphens only, max 18 characters"
+    condition     = length(var.namespace) <= 12 && can(regex("^[a-z0-9-]+$", var.namespace))
+    error_message = "Namespace must be lowercase alphanumeric and hyphens only, max 12 characters"
   }
 }
 


### PR DESCRIPTION
max of 18 can lead to

> Error: expected length of name_prefix to be in the range (1 - 38), got 123456789012345678-demo5678-eks-node-group-

Also, the namespace needs to start with a letter

> Error: first character of parameter group "name_prefix" must be a letter
with module.materialize_example_simple.module.materialize_infrastructure.module.database.module.db.module.db_parameter_group.aws_db_parameter_group.this[0],
 12:   name_prefix = local.name_prefix
