### PR TITLE
fix rollout vars and add balancer resource config args

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -83,13 +83,20 @@ variable "environment" {
 variable "materialize_instances" {
   description = "List of Materialize instances to be created."
   type = list(object({
-    name            = string
-    namespace       = string
-    database_name   = string
-    cpu_request     = string
-    memory_request  = string
-    memory_limit    = string
-    create_database = optional(bool)
+    name                    = string
+    namespace               = string
+    database_name           = string
+    cpu_request             = string
+    memory_request          = string
+    memory_limit            = string
+    create_database         = optional(bool)
+    in_place_rollout        = optional(bool, false)
+    request_rollout         = optional(string)
+    force_rollout           = optional(string)
+    balancer_memory_request = optional(string, "256Mi")
+    balancer_memory_limit   = optional(string, "256Mi")
+    balancer_cpu_request    = optional(string, "100m")
+
   }))
   default = []
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -51,6 +51,8 @@ module "materialize_infrastructure" {
 
   # Enable and configure Materialize operator
   install_materialize_operator = true
+  operator_version             = var.operator_version
+  orchestratord_version        = var.orchestratord_version
 
   # Once the operator is installed, you can define your Materialize instances here.
   materialize_instances = var.materialize_instances
@@ -80,12 +82,25 @@ variable "environment" {
   default     = "dev"
 }
 
+variable "operator_version" {
+  description = "Version of the Materialize operator to install"
+  type        = string
+  default     = null
+}
+
+variable "orchestratord_version" {
+  description = "Version of the Materialize orchestrator to install"
+  type        = string
+  default     = "v0.130.4"
+}
+
 variable "materialize_instances" {
   description = "List of Materialize instances to be created."
   type = list(object({
     name                    = string
     namespace               = string
     database_name           = string
+    environmentd_version    = optional(string, "v0.130.4")
     cpu_request             = string
     memory_request          = string
     memory_limit            = string

--- a/main.tf
+++ b/main.tf
@@ -145,10 +145,11 @@ locals {
 
   instances = [
     for instance in var.materialize_instances : {
-      name            = instance.name
-      namespace       = instance.namespace
-      database_name   = instance.database_name
-      create_database = instance.create_database
+      name                 = instance.name
+      namespace            = instance.namespace
+      database_name        = instance.database_name
+      create_database      = instance.create_database
+      environmentd_version = instance.environmentd_version
 
       metadata_backend_url = format(
         "postgres://%s:%s@%s/%s?sslmode=require",

--- a/main.tf
+++ b/main.tf
@@ -171,6 +171,11 @@ locals {
       memory_request = instance.memory_request
       memory_limit   = instance.memory_limit
 
+
+      balancer_cpu_request    = lookup(instance, "balancer_cpu_request", null)
+      balancer_memory_request = lookup(instance, "balancer_memory_request", null)
+      balancer_memory_limit   = lookup(instance, "balancer_memory_limit", null)
+
       # Rollout options
       in_place_rollout = instance.in_place_rollout
       request_rollout  = instance.request_rollout

--- a/main.tf
+++ b/main.tf
@@ -172,10 +172,9 @@ locals {
       memory_request = instance.memory_request
       memory_limit   = instance.memory_limit
 
-
-      balancer_cpu_request    = lookup(instance, "balancer_cpu_request", null)
-      balancer_memory_request = lookup(instance, "balancer_memory_request", null)
-      balancer_memory_limit   = lookup(instance, "balancer_memory_limit", null)
+      balancer_cpu_request    = instance.balancer_cpu_request
+      balancer_memory_request = instance.balancer_memory_request
+      balancer_memory_limit   = instance.balancer_memory_limit
 
       # Rollout options
       in_place_rollout = instance.in_place_rollout

--- a/variables.tf
+++ b/variables.tf
@@ -309,17 +309,20 @@ variable "helm_values" {
 variable "materialize_instances" {
   description = "Configuration for Materialize instances"
   type = list(object({
-    name                 = string
-    namespace            = optional(string)
-    database_name        = string
-    environmentd_version = optional(string, "v0.130.4")
-    cpu_request          = optional(string, "1")
-    memory_request       = optional(string, "1Gi")
-    memory_limit         = optional(string, "1Gi")
-    create_database      = optional(bool, true)
-    in_place_rollout     = optional(bool, false)
-    request_rollout      = optional(string)
-    force_rollout        = optional(string)
+    name                    = string
+    namespace               = optional(string)
+    database_name           = string
+    environmentd_version    = optional(string, "v0.130.4")
+    cpu_request             = optional(string, "1")
+    memory_request          = optional(string, "1Gi")
+    memory_limit            = optional(string, "1Gi")
+    create_database         = optional(bool, true)
+    in_place_rollout        = optional(bool, false)
+    request_rollout         = optional(string)
+    force_rollout           = optional(string)
+    balancer_memory_request = optional(string, "256Mi")
+    balancer_memory_limit   = optional(string, "256Mi")
+    balancer_cpu_request    = optional(string, "100m")
   }))
   default = []
 


### PR DESCRIPTION
Add balancerd resource requirements

blocked by: https://github.com/MaterializeInc/terraform-helm-materialize/pull/21

The simple example didn't have rollout args in the input variable... this seems broken so I added them. 
