### PR TITLE
NLB ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,12 @@ export AWS_PROFILE=your-profile-name
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_aws_lbc"></a> [aws\_lbc](#module\_aws\_lbc) | ./modules/aws-lbc | n/a |
 | <a name="module_database"></a> [database](#module\_database) | ./modules/database | n/a |
 | <a name="module_eks"></a> [eks](#module\_eks) | ./modules/eks | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
-| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.7 |
+| <a name="module_nlb"></a> [nlb](#module\_nlb) | ./modules/nlb | n/a |
+| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.8 |
 | <a name="module_storage"></a> [storage](#module\_storage) | ./modules/storage | n/a |
 
 ## Resources
@@ -118,15 +120,17 @@ export AWS_PROFILE=your-profile-name
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., prod, staging, dev) | `string` | n/a | yes |
 | <a name="input_helm_chart"></a> [helm\_chart](#input\_helm\_chart) | Chart name from repository or local path to chart. For local charts, set the path to the chart directory. | `string` | `"materialize-operator"` | no |
 | <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Additional Helm values to merge with defaults | `any` | `{}` | no |
+| <a name="input_install_aws_load_balancer_controller"></a> [install\_aws\_load\_balancer\_controller](#input\_install\_aws\_load\_balancer\_controller) | Whether to install the AWS Load Balancer Controller | `bool` | `true` | no |
 | <a name="input_install_materialize_operator"></a> [install\_materialize\_operator](#input\_install\_materialize\_operator) | Whether to install the Materialize operator | `bool` | `true` | no |
 | <a name="input_install_metrics_server"></a> [install\_metrics\_server](#input\_install\_metrics\_server) | Whether to install the metrics-server for the Materialize Console | `bool` | `true` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | The Kubernetes namespace for the Materialize resources | `string` | `"materialize-environment"` | no |
 | <a name="input_log_group_name_prefix"></a> [log\_group\_name\_prefix](#input\_log\_group\_name\_prefix) | Prefix for the CloudWatch log group name (will be combined with environment name) | `string` | `"materialize"` | no |
-| <a name="input_materialize_instances"></a> [materialize\_instances](#input\_materialize\_instances) | Configuration for Materialize instances | <pre>list(object({<br/>    name                    = string<br/>    namespace               = optional(string)<br/>    database_name           = string<br/>    environmentd_version    = optional(string, "v0.130.4")<br/>    cpu_request             = optional(string, "1")<br/>    memory_request          = optional(string, "1Gi")<br/>    memory_limit            = optional(string, "1Gi")<br/>    create_database         = optional(bool, true)<br/>    in_place_rollout        = optional(bool, false)<br/>    request_rollout         = optional(string)<br/>    force_rollout           = optional(string)<br/>    balancer_memory_request = optional(string, "256Mi")<br/>    balancer_memory_limit   = optional(string, "256Mi")<br/>    balancer_cpu_request    = optional(string, "100m")<br/>  }))</pre> | `[]` | no |
+| <a name="input_materialize_instances"></a> [materialize\_instances](#input\_materialize\_instances) | Configuration for Materialize instances | <pre>list(object({<br/>    name                    = string<br/>    namespace               = optional(string)<br/>    database_name           = string<br/>    environmentd_version    = optional(string, "v0.130.4")<br/>    cpu_request             = optional(string, "1")<br/>    memory_request          = optional(string, "1Gi")<br/>    memory_limit            = optional(string, "1Gi")<br/>    create_database         = optional(bool, true)<br/>    create_nlb              = optional(bool, true)<br/>    internal_nlb            = optional(bool, true)<br/>    in_place_rollout        = optional(bool, false)<br/>    request_rollout         = optional(string)<br/>    force_rollout           = optional(string)<br/>    balancer_memory_request = optional(string, "256Mi")<br/>    balancer_memory_limit   = optional(string, "256Mi")<br/>    balancer_cpu_request    = optional(string, "100m")<br/>  }))</pre> | `[]` | no |
 | <a name="input_metrics_retention_days"></a> [metrics\_retention\_days](#input\_metrics\_retention\_days) | Number of days to retain CloudWatch metrics | `number` | `7` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace for all resources, usually the organization or project name | `string` | n/a | yes |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the VPC in which resources will be deployed. Only used if create\_vpc is false. | `string` | `""` | no |
 | <a name="input_network_private_subnet_ids"></a> [network\_private\_subnet\_ids](#input\_network\_private\_subnet\_ids) | A list of private subnet IDs in the VPC. Only used if create\_vpc is false. | `list(string)` | `[]` | no |
+| <a name="input_network_public_subnet_ids"></a> [network\_public\_subnet\_ids](#input\_network\_public\_subnet\_ids) | A list of public subnet IDs in the VPC. Only used if create\_vpc is false. | `list(string)` | `[]` | no |
 | <a name="input_node_group_ami_type"></a> [node\_group\_ami\_type](#input\_node\_group\_ami\_type) | AMI type for the node group | `string` | `"AL2023_ARM_64_STANDARD"` | no |
 | <a name="input_node_group_capacity_type"></a> [node\_group\_capacity\_type](#input\_node\_group\_capacity\_type) | Capacity type for worker nodes (ON\_DEMAND or SPOT) | `string` | `"ON_DEMAND"` | no |
 | <a name="input_node_group_desired_size"></a> [node\_group\_desired\_size](#input\_node\_group\_desired\_size) | Desired number of worker nodes | `number` | `2` | no |
@@ -150,6 +154,7 @@ export AWS_PROFILE=your-profile-name
 | Name | Description |
 |------|-------------|
 | <a name="output_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#output\_cluster\_certificate\_authority\_data) | Base64 encoded certificate data required to communicate with the cluster |
+| <a name="output_cluster_oidc_issuer_url"></a> [cluster\_oidc\_issuer\_url](#output\_cluster\_oidc\_issuer\_url) | The URL on the EKS cluster for the OpenID Connect identity provider |
 | <a name="output_database_endpoint"></a> [database\_endpoint](#output\_database\_endpoint) | RDS instance endpoint |
 | <a name="output_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#output\_eks\_cluster\_endpoint) | EKS cluster endpoint |
 | <a name="output_eks_cluster_name"></a> [eks\_cluster\_name](#output\_eks\_cluster\_name) | EKS cluster name |
@@ -158,6 +163,8 @@ export AWS_PROFILE=your-profile-name
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | The ARN of the OIDC Provider |
 | <a name="output_operator_details"></a> [operator\_details](#output\_operator\_details) | Details of the installed Materialize operator |
 | <a name="output_persist_backend_url"></a> [persist\_backend\_url](#output\_persist\_backend\_url) | S3 connection URL in the format required by Materialize using IRSA |
+| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | List of private subnet IDs |
+| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | List of public subnet IDs |
 | <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name) | Name of the S3 bucket |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID |
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -135,13 +135,14 @@ variable "materialize_instances" {
     memory_request          = string
     memory_limit            = string
     create_database         = optional(bool)
+    create_nlb              = optional(bool)
+    internal_nlb            = optional(bool)
     in_place_rollout        = optional(bool, false)
     request_rollout         = optional(string)
     force_rollout           = optional(string)
     balancer_memory_request = optional(string, "256Mi")
     balancer_memory_limit   = optional(string, "256Mi")
     balancer_cpu_request    = optional(string, "100m")
-
   }))
   default = []
 }

--- a/main.tf
+++ b/main.tf
@@ -138,12 +138,13 @@ module "nlb" {
 
   for_each = { for idx, instance in local.instances : instance.name => instance if lookup(instance, "create_nlb", true) }
 
-  name_prefix    = each.value.name
-  namespace      = each.value.namespace
-  internal       = each.value.internal_nlb
-  subnet_ids     = each.value.internal_nlb ? local.network_private_subnet_ids : local.network_public_subnet_ids
-  vpc_id         = local.network_id
-  mz_resource_id = module.operator[0].materialize_instance_resource_ids[each.value.name]
+  name_prefix                      = each.value.name
+  namespace                        = each.value.namespace
+  internal                         = each.value.internal_nlb
+  subnet_ids                       = each.value.internal_nlb ? local.network_private_subnet_ids : local.network_public_subnet_ids
+  enable_cross_zone_load_balancing = each.value.enable_cross_zone_load_balancing
+  vpc_id                           = local.network_id
+  mz_resource_id                   = module.operator[0].materialize_instance_resource_ids[each.value.name]
 
   depends_on = [
     module.aws_lbc,
@@ -189,13 +190,14 @@ locals {
 
   instances = [
     for instance in var.materialize_instances : {
-      name                 = instance.name
-      namespace            = instance.namespace
-      database_name        = instance.database_name
-      create_database      = instance.create_database
-      environmentd_version = instance.environmentd_version
-      create_nlb           = instance.create_nlb
-      internal_nlb         = instance.internal_nlb
+      name                             = instance.name
+      namespace                        = instance.namespace
+      database_name                    = instance.database_name
+      create_database                  = instance.create_database
+      environmentd_version             = instance.environmentd_version
+      create_nlb                       = instance.create_nlb
+      internal_nlb                     = instance.internal_nlb
+      enable_cross_zone_load_balancing = instance.enable_cross_zone_load_balancing
 
       metadata_backend_url = format(
         "postgres://%s:%s@%s/%s?sslmode=require",

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,25 @@ module "eks" {
   enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
 
   tags = local.common_tags
+
+  depends_on = [
+    module.networking,
+  ]
+}
+
+module "aws_lbc" {
+  source = "./modules/aws-lbc"
+  count  = var.install_aws_load_balancer_controller ? 1 : 0
+
+  eks_cluster_name  = module.eks.cluster_name
+  oidc_provider_arn = module.eks.oidc_provider_arn
+  oidc_issuer_url   = module.eks.cluster_oidc_issuer_url
+  vpc_id            = module.networking.vpc_id
+  region            = data.aws_region.current.name
+
+  depends_on = [
+    module.eks,
+  ]
 }
 
 module "storage" {
@@ -76,10 +95,14 @@ module "database" {
   database_password          = var.database_password
 
   tags = local.common_tags
+
+  depends_on = [
+    module.networking,
+  ]
 }
 
 module "operator" {
-  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.7"
+  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.8"
 
   count = var.install_materialize_operator ? 1 : 0
 
@@ -88,7 +111,8 @@ module "operator" {
   depends_on = [
     module.eks,
     module.database,
-    module.storage
+    module.storage,
+    module.networking,
   ]
 
   namespace          = var.namespace
@@ -109,9 +133,29 @@ module "operator" {
   }
 }
 
+module "nlb" {
+  source = "./modules/nlb"
+
+  for_each = { for idx, instance in local.instances : instance.name => instance if lookup(instance, "create_nlb", true) }
+
+  name_prefix    = each.value.name
+  namespace      = each.value.namespace
+  internal       = each.value.internal_nlb
+  subnet_ids     = each.value.internal_nlb ? local.network_private_subnet_ids : local.network_public_subnet_ids
+  vpc_id         = local.network_id
+  mz_resource_id = module.operator[0].materialize_instance_resource_ids[each.value.name]
+
+  depends_on = [
+    module.aws_lbc,
+    module.operator,
+    module.eks,
+  ]
+}
+
 locals {
   network_id                 = var.create_vpc ? module.networking.vpc_id : var.network_id
   network_private_subnet_ids = var.create_vpc ? module.networking.private_subnet_ids : var.network_private_subnet_ids
+  network_public_subnet_ids  = var.create_vpc ? module.networking.public_subnet_ids : var.network_public_subnet_ids
 
   default_helm_values = {
     observability = {
@@ -150,6 +194,8 @@ locals {
       database_name        = instance.database_name
       create_database      = instance.create_database
       environmentd_version = instance.environmentd_version
+      create_nlb           = instance.create_nlb
+      internal_nlb         = instance.internal_nlb
 
       metadata_backend_url = format(
         "postgres://%s:%s@%s/%s?sslmode=require",

--- a/modules/aws-lbc/main.tf
+++ b/modules/aws-lbc/main.tf
@@ -1,0 +1,326 @@
+resource "aws_iam_policy" "aws_load_balancer_controller" {
+  name        = var.iam_name
+  description = "AWS Load balancer controller"
+  # From https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.11.0/docs/install/iam_policy.json
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeListenerAttributes",
+                "elasticloadbalancing:DescribeCapacityReservation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyListenerAttributes",
+                "elasticloadbalancing:ModifyCapacityReservation"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role" "aws_load_balancer_controller" {
+  name = var.iam_name
+  assume_role_policy = jsonencode(
+    {
+      Version : "2012-10-17",
+      Statement : [
+        {
+          Effect : "Allow",
+          Principal : {
+            Federated : var.oidc_provider_arn,
+          },
+          Action : "sts:AssumeRoleWithWebIdentity",
+          Condition : {
+            StringEquals : {
+              "${trimprefix(var.oidc_issuer_url, "https://")}:sub" : "system:serviceaccount:${var.namespace}:${var.service_account_name}",
+            },
+          },
+        },
+      ],
+    },
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller" {
+  role       = aws_iam_role.aws_load_balancer_controller.name
+  policy_arn = aws_iam_policy.aws_load_balancer_controller.arn
+}
+
+resource "kubernetes_service_account" "aws_load_balancer_controller" {
+  metadata {
+    name      = var.service_account_name
+    namespace = var.namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" : aws_iam_role.aws_load_balancer_controller.arn
+    }
+  }
+}
+
+resource "helm_release" "aws_load_balancer_controller" {
+  name       = "aws-load-balancer-controller"
+  chart      = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  version    = "1.11.0"
+  namespace  = "kube-system"
+
+  set {
+    name  = "clusterName"
+    value = var.eks_cluster_name
+  }
+  set {
+    name  = "serviceAccount.create"
+    value = false
+  }
+  set {
+    name  = "serviceAccount.name"
+    value = var.service_account_name
+  }
+  set {
+    name  = "region"
+    value = var.region
+  }
+  set {
+    name  = "vpcId"
+    value = var.vpc_id
+  }
+
+  depends_on = [
+    kubernetes_service_account.aws_load_balancer_controller,
+    aws_iam_role_policy_attachment.aws_load_balancer_controller,
+  ]
+}

--- a/modules/aws-lbc/variables.tf
+++ b/modules/aws-lbc/variables.tf
@@ -1,0 +1,42 @@
+variable "namespace" {
+  description = "Namespace to install the AWS LBC"
+  type        = string
+  default     = "kube-system"
+}
+
+variable "service_account_name" {
+  description = "Name of the Kubernetes service account used by the AWS LBC"
+  type        = string
+  default     = "aws-load-balancer-controller"
+}
+
+variable "iam_name" {
+  description = "Name of the AWS IAM role and policy"
+  type        = string
+  default     = "aws-load-balancer-controller"
+}
+
+variable "eks_cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+
+variable "oidc_provider_arn" {
+  description = "ARN of the EKS cluster OIDC provider"
+  type        = string
+}
+
+variable "oidc_issuer_url" {
+  description = "URL of the EKS cluster OIDC issuer"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region of the VPC"
+  type        = string
+}

--- a/modules/aws-lbc/versions.tf
+++ b/modules/aws-lbc/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -39,6 +39,36 @@ module "eks" {
     }
   }
 
+  node_security_group_additional_rules = {
+    mz_ingress_http = {
+      description      = "Ingress to materialize balancers HTTP"
+      protocol         = "tcp"
+      from_port        = 6876
+      to_port          = 6876
+      type             = "ingress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    }
+    mz_ingress_pgwire = {
+      description      = "Ingress to materialize balancers pgwire"
+      protocol         = "tcp"
+      from_port        = 6875
+      to_port          = 6875
+      type             = "ingress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    }
+    mz_ingress_nlb_health_checks = {
+      description      = "Ingress to materialize balancer health checks and console"
+      protocol         = "tcp"
+      from_port        = 8080
+      to_port          = 8080
+      type             = "ingress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    }
+  }
+
   # Cluster access entry
   # To add the current caller identity as an administrator
   enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions

--- a/modules/nlb/main.tf
+++ b/modules/nlb/main.tf
@@ -1,8 +1,9 @@
 resource "aws_lb" "nlb" {
-  name               = var.name_prefix
-  internal           = var.internal
-  load_balancer_type = "network"
-  subnets            = var.subnet_ids
+  name                             = var.name_prefix
+  internal                         = var.internal
+  load_balancer_type               = "network"
+  subnets                          = var.subnet_ids
+  enable_cross_zone_load_balancing = var.enable_cross_zone_load_balancing
 }
 
 module "target_pgwire" {

--- a/modules/nlb/main.tf
+++ b/modules/nlb/main.tf
@@ -1,0 +1,42 @@
+resource "aws_lb" "nlb" {
+  name               = var.name_prefix
+  internal           = var.internal
+  load_balancer_type = "network"
+  subnets            = var.subnet_ids
+}
+
+module "target_pgwire" {
+  source = "./target"
+
+  name              = "pgwire"
+  nlb_arn           = aws_lb.nlb.arn
+  namespace         = var.namespace
+  vpc_id            = var.vpc_id
+  port              = 6875
+  service_name      = "mz${var.mz_resource_id}-balancerd"
+  health_check_path = "/api/readyz"
+}
+
+module "target_http" {
+  source = "./target"
+
+  name              = "http"
+  nlb_arn           = aws_lb.nlb.arn
+  namespace         = var.namespace
+  vpc_id            = var.vpc_id
+  port              = 6876
+  service_name      = "mz${var.mz_resource_id}-balancerd"
+  health_check_path = "/api/readyz"
+}
+
+module "target_console" {
+  source = "./target"
+
+  name              = "console"
+  nlb_arn           = aws_lb.nlb.arn
+  namespace         = var.namespace
+  vpc_id            = var.vpc_id
+  port              = 8080
+  service_name      = "mz${var.mz_resource_id}-console"
+  health_check_path = "/"
+}

--- a/modules/nlb/target/main.tf
+++ b/modules/nlb/target/main.tf
@@ -1,9 +1,10 @@
 resource "aws_lb_target_group" "target_group" {
-  name        = var.name
-  port        = var.port
-  protocol    = "TCP"
-  target_type = "ip"
-  vpc_id      = var.vpc_id
+  name               = var.name
+  port               = var.port
+  preserve_client_ip = true
+  protocol           = "TCP"
+  target_type        = "ip"
+  vpc_id             = var.vpc_id
 
   health_check {
     enabled             = true

--- a/modules/nlb/target/main.tf
+++ b/modules/nlb/target/main.tf
@@ -1,0 +1,64 @@
+resource "aws_lb_target_group" "target_group" {
+  name        = var.name
+  port        = var.port
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 10
+    protocol            = "HTTP"
+    port                = 8080
+    path                = var.health_check_path
+    matcher             = "200"
+    timeout             = 10
+  }
+
+  stickiness {
+    enabled = true
+    type    = "source_ip"
+  }
+}
+
+resource "aws_lb_listener" "listener" {
+  load_balancer_arn = var.nlb_arn
+  port              = var.port
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.target_group.arn
+  }
+}
+
+resource "kubernetes_manifest" "target_group_binding" {
+  manifest = {
+    "apiVersion" = "elbv2.k8s.aws/v1beta1"
+    "kind"       = "TargetGroupBinding"
+    "metadata" = {
+      "name"      = var.name
+      "namespace" = var.namespace
+    }
+    "spec" = {
+      "serviceRef" = {
+        "name" = var.service_name
+        "port" = var.port
+      }
+      "targetGroupARN" = aws_lb_target_group.target_group.arn
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      manifest.spec.serviceRef.name,
+    ]
+  }
+
+  depends_on = [
+    aws_lb_listener.listener,
+    aws_lb_target_group.target_group,
+  ]
+}

--- a/modules/nlb/target/variables.tf
+++ b/modules/nlb/target/variables.tf
@@ -1,0 +1,34 @@
+variable "name" {
+  description = "Name for Target Groups and TargetGroupBindings"
+  type        = string
+}
+
+variable "nlb_arn" {
+  description = "ARN of the NLB"
+  type        = string
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace in which to install TargetGroupBindings"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+}
+
+variable "port" {
+  description = "Port for the NLB listener and Kubernetes service"
+  type        = number
+}
+
+variable "health_check_path" {
+  description = "The URL path for target group health checks"
+  type        = string
+}
+
+variable "service_name" {
+  description = "The name of the Kubernetes service to connect to"
+  type        = string
+}

--- a/modules/nlb/target/versions.tf
+++ b/modules/nlb/target/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/nlb/variables.tf
+++ b/modules/nlb/variables.tf
@@ -1,0 +1,30 @@
+variable "name_prefix" {
+  description = "Prefix to use for NLB, Target Groups, Listeners, and TargetGroupBindings"
+  type        = string
+}
+
+variable "internal" {
+  description = "Whether the NLB is an internal only NLB."
+  type        = bool
+  default     = true
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace in which to install TargetGroupBindings"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "A list of subnet IDs in which to install the NLB. Must be in the VPC."
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+}
+
+variable "mz_resource_id" {
+  description = "The resourceId from the Materialize CR"
+  type        = string
+}

--- a/modules/nlb/variables.tf
+++ b/modules/nlb/variables.tf
@@ -28,3 +28,9 @@ variable "mz_resource_id" {
   description = "The resourceId from the Materialize CR"
   type        = string
 }
+
+variable "enable_cross_zone_load_balancing" {
+  description = "Whether to enable cross zone load balancing on the NLB."
+  type        = bool
+  default     = true
+}

--- a/modules/nlb/versions.tf
+++ b/modules/nlb/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,16 @@ output "vpc_id" {
   value       = module.networking.vpc_id
 }
 
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = module.networking.private_subnet_ids
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = module.networking.public_subnet_ids
+}
+
 output "eks_cluster_endpoint" {
   description = "EKS cluster endpoint"
   value       = module.eks.cluster_endpoint
@@ -53,6 +63,11 @@ output "persist_backend_url" {
 output "oidc_provider_arn" {
   description = "The ARN of the OIDC Provider"
   value       = module.eks.oidc_provider_arn
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "The URL on the EKS cluster for the OpenID Connect identity provider"
+  value       = module.eks.cluster_oidc_issuer_url
 }
 
 # aws_iam_role.materialize_s3.arn

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,12 @@ variable "network_private_subnet_ids" {
   type        = list(string)
 }
 
+variable "network_public_subnet_ids" {
+  default     = []
+  description = "A list of public subnet IDs in the VPC. Only used if create_vpc is false."
+  type        = list(string)
+}
+
 variable "vpc_cidr" {
   description = "CIDR block for VPC"
   type        = string
@@ -261,6 +267,12 @@ variable "log_group_name_prefix" {
   default     = "materialize"
 }
 
+variable "install_aws_load_balancer_controller" {
+  description = "Whether to install the AWS Load Balancer Controller"
+  type        = bool
+  default     = true
+}
+
 # Materialize Helm Chart Variables
 variable "install_materialize_operator" {
   description = "Whether to install the Materialize operator"
@@ -315,6 +327,8 @@ variable "materialize_instances" {
     memory_request          = optional(string, "1Gi")
     memory_limit            = optional(string, "1Gi")
     create_database         = optional(bool, true)
+    create_nlb              = optional(bool, true)
+    internal_nlb            = optional(bool, true)
     in_place_rollout        = optional(bool, false)
     request_rollout         = optional(string)
     force_rollout           = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -319,22 +319,23 @@ variable "helm_values" {
 variable "materialize_instances" {
   description = "Configuration for Materialize instances"
   type = list(object({
-    name                    = string
-    namespace               = optional(string)
-    database_name           = string
-    environmentd_version    = optional(string, "v0.130.4")
-    cpu_request             = optional(string, "1")
-    memory_request          = optional(string, "1Gi")
-    memory_limit            = optional(string, "1Gi")
-    create_database         = optional(bool, true)
-    create_nlb              = optional(bool, true)
-    internal_nlb            = optional(bool, true)
-    in_place_rollout        = optional(bool, false)
-    request_rollout         = optional(string)
-    force_rollout           = optional(string)
-    balancer_memory_request = optional(string, "256Mi")
-    balancer_memory_limit   = optional(string, "256Mi")
-    balancer_cpu_request    = optional(string, "100m")
+    name                             = string
+    namespace                        = optional(string)
+    database_name                    = string
+    environmentd_version             = optional(string, "v0.130.4")
+    cpu_request                      = optional(string, "1")
+    memory_request                   = optional(string, "1Gi")
+    memory_limit                     = optional(string, "1Gi")
+    create_database                  = optional(bool, true)
+    create_nlb                       = optional(bool, true)
+    internal_nlb                     = optional(bool, true)
+    enable_cross_zone_load_balancing = optional(bool, true)
+    in_place_rollout                 = optional(bool, false)
+    request_rollout                  = optional(string)
+    force_rollout                    = optional(string)
+    balancer_memory_request          = optional(string, "256Mi")
+    balancer_memory_limit            = optional(string, "256Mi")
+    balancer_cpu_request             = optional(string, "100m")
   }))
   default = []
 


### PR DESCRIPTION
NLB ingress to balancerd and the console.

This still works for TLS for balancers, but TLS for console doesn't work. This is not a problem with this PR, but with the configuration of the console pods having incorrect permissions when instantiated with v0.130.4 orchestratord.

Resolves https://github.com/MaterializeInc/cloud/issues/10877