### PR TITLE
Fix aws lb controller naming collision

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,7 @@ module "aws_lbc" {
   source = "./modules/aws-lbc"
   count  = var.install_aws_load_balancer_controller ? 1 : 0
 
+  name_prefix       = "${var.namespace}-${var.environment}"
   eks_cluster_name  = module.eks.cluster_name
   oidc_provider_arn = module.eks.oidc_provider_arn
   oidc_issuer_url   = module.eks.cluster_oidc_issuer_url

--- a/modules/aws-lbc/main.tf
+++ b/modules/aws-lbc/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "aws_load_balancer_controller" {
-  name        = var.iam_name
+  name        = "${var.name_prefix}-${var.iam_name}"
   description = "AWS Load balancer controller"
   # From https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.11.0/docs/install/iam_policy.json
   policy = <<EOF
@@ -254,7 +254,7 @@ EOF
 }
 
 resource "aws_iam_role" "aws_load_balancer_controller" {
-  name = var.iam_name
+  name = "${var.name_prefix}-${var.iam_name}"
   assume_role_policy = jsonencode(
     {
       Version : "2012-10-17",

--- a/modules/aws-lbc/variables.tf
+++ b/modules/aws-lbc/variables.tf
@@ -4,6 +4,12 @@ variable "namespace" {
   default     = "kube-system"
 }
 
+variable "name_prefix" {
+  description = "Prefix to use for AWS LBC resources"
+  type        = string
+  default     = ""
+}
+
 variable "service_account_name" {
   description = "Name of the Kubernetes service account used by the AWS LBC"
   type        = string
@@ -13,7 +19,7 @@ variable "service_account_name" {
 variable "iam_name" {
   description = "Name of the AWS IAM role and policy"
   type        = string
-  default     = "aws-load-balancer-controller"
+  default     = "albc"
 }
 
 variable "eks_cluster_name" {


### PR DESCRIPTION
Updating the AWS LB controller `aws_iam_policy` to use the naming prefix as we do throughout the module to avoid naming collisions and not ask users to individual specify names.