### PR TITLE
remove default environmentd_version

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -136,7 +136,7 @@ variable "materialize_instances" {
     name                    = string
     namespace               = string
     database_name           = string
-    environmentd_version    = optional(string, "v0.130.4")
+    environmentd_version    = optional(string)
     cpu_request             = string
     memory_request          = string
     memory_limit            = string

--- a/variables.tf
+++ b/variables.tf
@@ -352,7 +352,7 @@ variable "materialize_instances" {
     name                             = string
     namespace                        = optional(string)
     database_name                    = string
-    environmentd_version             = optional(string, "v0.130.4")
+    environmentd_version             = optional(string)
     cpu_request                      = optional(string, "1")
     memory_request                   = optional(string, "1Gi")
     memory_limit                     = optional(string, "1Gi")


### PR DESCRIPTION
FYI - To test, I locally set the operator source ref to main  (instead of v0.1.9) since the bump of the environmentd values occurred after that tag.