### PR TITLE
Bump for terraform-helm-materialize v0.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module for deploying Materialize on AWS Cloud Platform with all requir
 The module has been tested with:
 
 - PostgreSQL 15
-- Materialize Helm Operator Terraform Module v0.1.8
+- Materialize Helm Operator Terraform Module v0.1.12
 
 > [!WARNING]
 > This module is intended for demonstration/evaluation purposes as well as for serving as a template when building your own production deployment of Materialize.
@@ -122,7 +122,7 @@ disk_support_config = {
 | <a name="module_eks"></a> [eks](#module\_eks) | ./modules/eks | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./modules/networking | n/a |
 | <a name="module_nlb"></a> [nlb](#module\_nlb) | ./modules/nlb | n/a |
-| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.11 |
+| <a name="module_operator"></a> [operator](#module\_operator) | github.com/MaterializeInc/terraform-helm-materialize | v0.1.12 |
 | <a name="module_storage"></a> [storage](#module\_storage) | ./modules/storage | n/a |
 
 ## Resources

--- a/docs/header.md
+++ b/docs/header.md
@@ -5,7 +5,7 @@ Terraform module for deploying Materialize on AWS Cloud Platform with all requir
 The module has been tested with:
 
 - PostgreSQL 15
-- Materialize Helm Operator Terraform Module v0.1.8
+- Materialize Helm Operator Terraform Module v0.1.12
 
 > [!WARNING]
 > This module is intended for demonstration/evaluation purposes as well as for serving as a template when building your own production deployment of Materialize.

--- a/main.tf
+++ b/main.tf
@@ -128,7 +128,7 @@ module "certificates" {
 }
 
 module "operator" {
-  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.11"
+  source = "github.com/MaterializeInc/terraform-helm-materialize?ref=v0.1.12"
 
   count = var.install_materialize_operator ? 1 : 0
 


### PR DESCRIPTION
verified via `kubectl describe`
- `Container image "materialize/orchestratord:v0.138.0" already present on machine`
- `Pulling image "materialize/environmentd:v0.130.8"`

and via console 

<img width="626" alt="Screenshot 2025-04-08 at 2 33 08 PM" src="https://github.com/user-attachments/assets/5cd6d1a1-8627-446c-af32-20b62bc900dd" />
