### PR TITLE
Configure a statement timout for the database

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -270,11 +270,12 @@ locals {
       environmentd_extra_args          = instance.environmentd_extra_args
 
       metadata_backend_url = format(
-        "postgres://%s:%s@%s/%s?sslmode=require",
+        "postgres://%s:%s@%s/%s?sslmode=require&options=-c%%20statement_timeout%%3D%s",
         var.database_username,
         urlencode(var.database_password),
         module.database.db_instance_endpoint,
-        coalesce(instance.database_name, instance.name)
+        coalesce(instance.database_name, instance.name),
+        var.database_statement_timeout
       )
 
       persist_backend_url = format(

--- a/outputs.tf
+++ b/outputs.tf
@@ -40,11 +40,12 @@ output "s3_bucket_name" {
 
 output "metadata_backend_url" {
   description = "PostgreSQL connection URL in the format required by Materialize"
-  value = format("postgres://%s:%s@%s/%s?sslmode=require",
+  value = format("postgres://%s:%s@%s/%s?sslmode=require&options=-c%%20statement_timeout%%3D%s",
     var.database_username,
     var.database_password,
     module.database.db_instance_endpoint,
-    var.database_name
+    var.database_name,
+    var.database_statement_timeout
   )
   sensitive = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -191,6 +191,12 @@ variable "database_password" {
   }
 }
 
+variable "database_statement_timeout" {
+  description = "Statement timeout for the database"
+  type        = string
+  default     = "15min"
+}
+
 variable "db_multi_az" {
   description = "Enable multi-AZ deployment for RDS"
   type        = bool


### PR DESCRIPTION
This allows the terraform user to set a particular statement timeout in the connection string, preventing a hung pod from interfering with other clients.