### PR TITLE
Parameterize Health Checks on Target Groups

### DIFF
--- a/modules/nlb/main.tf
+++ b/modules/nlb/main.tf
@@ -16,6 +16,7 @@ module "target_pgwire" {
   port              = 6875
   service_name      = "mz${var.mz_resource_id}-balancerd"
   health_check_path = "/api/readyz"
+  health_check_protocol = "HTTP"
 }
 
 module "target_http" {
@@ -28,6 +29,7 @@ module "target_http" {
   port              = 6876
   service_name      = "mz${var.mz_resource_id}-balancerd"
   health_check_path = "/api/readyz"
+  health_check_protocol = "HTTP"
 }
 
 module "target_console" {
@@ -40,4 +42,5 @@ module "target_console" {
   port              = 8080
   service_name      = "mz${var.mz_resource_id}-console"
   health_check_path = "/"
+  health_check_protocol = "HTTPS"
 }

--- a/modules/nlb/target/main.tf
+++ b/modules/nlb/target/main.tf
@@ -11,7 +11,7 @@ resource "aws_lb_target_group" "target_group" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10
-    protocol            = "HTTP"
+    protocol            = var.health_check_protocol
     port                = 8080
     path                = var.health_check_path
     matcher             = "200"

--- a/modules/nlb/target/variables.tf
+++ b/modules/nlb/target/variables.tf
@@ -23,6 +23,11 @@ variable "port" {
   type        = number
 }
 
+variable "health_check_protocol" {
+  description = "The protocol to use for the health check"
+  type        = string
+}
+
 variable "health_check_path" {
   description = "The URL path for target group health checks"
   type        = string


### PR DESCRIPTION
Setting up a default deployment of Materialize in AWS results in target group instances reporting unhealthy for the console. Updating to HTTPS fixes this issue. 