### PR TITLE
Upgrade openebs to 4.3.3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -325,7 +325,7 @@ locals {
     install_openebs           = var.enable_disk_support ? lookup(var.disk_support_config, "install_openebs", true) : false
     run_disk_setup_script     = var.enable_disk_support ? lookup(var.disk_support_config, "run_disk_setup_script", true) : false
     create_storage_class      = var.enable_disk_support ? lookup(var.disk_support_config, "create_storage_class", true) : false
-    openebs_version           = lookup(var.disk_support_config, "openebs_version", "4.2.0")
+    openebs_version           = lookup(var.disk_support_config, "openebs_version", "4.3.3")
     openebs_namespace         = lookup(var.disk_support_config, "openebs_namespace", "openebs")
     storage_class_name        = lookup(var.disk_support_config, "storage_class_name", "openebs-lvm-instance-store-ext4")
     storage_class_provisioner = lookup(var.disk_support_config, "storage_class_provisioner", "local.csi.openebs.io")

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -104,10 +104,57 @@ resource "helm_release" "openebs" {
   chart      = "openebs"
   version    = var.openebs_version
 
-  set {
-    name  = "engines.replicated.mayastor.enabled"
-    value = "false"
-  }
+  values = [jsonencode({
+    "alloy" : {
+      "enabled" : false,
+    },
+    "localpv-provisioner" : {
+      "localpv" : {
+        "enabled" : false,
+      },
+      "hostpathClass" : {
+        "enabled" : false,
+      },
+      "serviceAccount" : {
+        "create" : false,
+      },
+    },
+    "zfs-localpv" : {
+      "enabled" : false,
+    },
+    "loki" : {
+      "enabled" : false,
+    },
+    "mayastor" : {
+      "enabled" : false,
+    },
+    "minio" : {
+      "enabled" : false,
+    },
+    "lvm-localpv" : {
+      "analytics" : {
+        "enabled" : false,
+      },
+      "lvmNode" : {
+        "nodeSelector" : {
+          "materialize.cloud/scratch-fs" : "true",
+          "workload" : "materialize-instance",
+        },
+      },
+    },
+    "engines" : {
+      "local" : {
+        "zfs" : {
+          "enabled" : false,
+        },
+      },
+      "replicated" : {
+        "mayastor" : {
+          "enabled" : false,
+        },
+      },
+    },
+  })]
 
   depends_on = [kubernetes_namespace.openebs]
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -89,7 +89,7 @@ variable "openebs_namespace" {
 variable "openebs_version" {
   description = "Version of OpenEBS Helm chart to install"
   type        = string
-  default     = "4.2.0"
+  default     = "4.3.3"
 }
 
 variable "enable_disk_setup" {

--- a/variables.tf
+++ b/variables.tf
@@ -410,7 +410,7 @@ variable "disk_support_config" {
     install_openebs           = optional(bool, true)
     run_disk_setup_script     = optional(bool, true)
     create_storage_class      = optional(bool, true)
-    openebs_version           = optional(string, "4.2.0")
+    openebs_version           = optional(string, "4.3.3")
     openebs_namespace         = optional(string, "openebs")
     storage_class_name        = optional(string, "openebs-lvm-instance-store-ext4")
     storage_class_provisioner = optional(string, "local.csi.openebs.io")


### PR DESCRIPTION
Upgrade openebs to 4.3.3, and disables all its features we don't use.

The previous version pulled an ancient kubectl image that was no longer available for a `Job`, which blocked its deployment.